### PR TITLE
Design for Hyperlinks

### DIFF
--- a/glossary/d.md
+++ b/glossary/d.md
@@ -1,6 +1,6 @@
 # D
 
-**DIRAC**
-: DIRAC stands for Distributed Infrastructure with Remote Agent Control.
-It is the software framework for distributed computing used in LHCb.
+## DIRAC: Distributed Infrastructure with Remote Agent Control {#DIRAC}
+
+DIRAC is the software framework for distributed computing used in LHCb.
 Official [DIRAC website](http://diracgrid.org/).

--- a/glossary/e.md
+++ b/glossary/e.md
@@ -1,6 +1,7 @@
 # E
 
-**ECGD**
-: The Early Career, Gender and Diversity office has been set up to help LHCb achieve a healthy working environment
+## ECGD: Early Career, Gender and Diversity {#ECGD}
+
+The Early Career, Gender and Diversity office has been set up to help LHCb achieve a healthy working environment
 with no discrimination on grounds of gender, sexual orientation, ethnicity, disability, creed, cultural background, etc.
 See the [ECGD office webpages](http://lhcb.web.cern.ch/lhcb/ECGD_Office/ECGD-intro.html) for more information.

--- a/glossary/g.md
+++ b/glossary/g.md
@@ -1,5 +1,6 @@
 # G
 
-**Gaudi**
-: The **LHCb** software framework, see the [Gaudi homepage](http://gaudi.web.cern.ch/gaudi/) and the [**Starterkit** high level overview](https://lhcb.github.io/starterkit-lessons/first-analysis-steps/davinci.html) for more details
+## Gaudi
+
+The **LHCb** software framework, see the [Gaudi homepage](http://gaudi.web.cern.ch/gaudi/) and the [**Starterkit** high level overview](https://lhcb.github.io/starterkit-lessons/first-analysis-steps/davinci.html) for more details
 

--- a/glossary/v.md
+++ b/glossary/v.md
@@ -1,5 +1,5 @@
 # V
 
-**VELO**
-: The LHCb VErtex LOcator.
+## VELO: VErtex LOcator {#VELO}
+
 [Twiki](https://lbtwiki.cern.ch/bin/view/VELO) for the VELO project.

--- a/styles/website.css
+++ b/styles/website.css
@@ -1,0 +1,5 @@
+
+.markdown-section h2 {
+    font-size: 1.25em;
+    margin-bottom: 0em;
+}


### PR DESCRIPTION
The new design:

```markdown

## TERM: The Expanded Real Message {#TERM}

Text.
```

There should be two `##`, followed by the definition. If this expands to something, you should add that in the same line after a colon, and then put a `{#hyperlink}` to just the unexpanded term.

Example:

```markdown
## DOCA: Distance Of Closest Approach {#DOCA}

This is the definition of DOCA.
```