### PR TITLE
Adding summary

### DIFF
--- a/.ci/prepare.py
+++ b/.ci/prepare.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+'''
+Preprocessing script for LHCb Glossary gitbook.
+
+'''
+
+from pathlib import Path
+import re
+
+title_pattern = re.compile(r'''
+    ^\#\#            # Starting two #
+    \w*              # Optional unlimited whitespace
+(?P<name> [^\{]*)    # Non-greedy anything but {
+(?: \{\#
+  (?P<link> .*)
+\}  )?               # Links (Optional)
+    \w*$             # End of string and optional whitespace
+
+''', re.VERBOSE)
+
+DIR = Path(__file__).resolve().parent
+base = './glossary'
+
+with open('README.md', 'w') as out:
+    print("# LHCb Glossary\n", file=out)
+    print("Glossary of HEP and LHCb-specific terms and concepts - make a pull request at <github.com/lhcb/glossary>\n", file=out)
+    print("## Terms:\n", file=out)
+
+    for fn in sorted((DIR.parent / 'glossary').glob('?.md')):
+        letter = fn.stem
+        with open(fn) as f:
+            for line in f:
+                if line.startswith('##'):
+                    d = title_pattern.match(line).groupdict()
+                    name = d['name'].strip()
+                    link = d['link'] if d['link'] is not None else (name.replace(' ', '-')
+                                                                        .replace(':', '')
+                                                                        .replace('(', '')
+                                                                        .replace(')','')
+                                                                        .lower())
+
+                    print(f"* [{name}]({base}/{letter}.md#{link})", file=out)
+

--- a/.ci/prepare.py
+++ b/.ci/prepare.py
@@ -22,9 +22,9 @@ title_pattern = re.compile(r'''
 DIR = Path(__file__).resolve().parent
 base = './glossary'
 
-with open('README.md', 'w') as out:
+with open('gitbook_readme.md', 'w') as out:
     print("# LHCb Glossary\n", file=out)
-    print("Glossary of HEP and LHCb-specific terms and concepts - make a pull request at <github.com/lhcb/glossary>\n", file=out)
+    print("Glossary of HEP and LHCb-specific terms and concepts - make a pull request at <https://github.com/lhcb/glossary>\n", file=out)
     print("## Terms:\n", file=out)
 
     for fn in sorted((DIR.parent / 'glossary').glob('?.md')):

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
-language: node_js
+dist: xenial
+language: python
 node_js:
   - "node"
+python:
+  - "3.7"
+
 branches:
   only:
     - master
+
 before_install:
   - npm install gitbook-cli -g
 install:
   - gitbook install
 script:
+  - python3 .ci/prepare.py
   - gitbook build
 deploy:
   provider: pages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LHCb Glossary
 
-Glossary of HEP and LHCb-specific terms and concepts - online at [https://lhcb.github.io/glossary/](https://lhcb.github.io/glossary/).
+Glossary of HEP and LHCb-specific terms and concepts - online at <https://lhcb.github.io/glossary/>.
 
 
 [**A**](glossary/a.md)&nbsp;&nbsp;&nbsp;&nbsp;

--- a/book.json
+++ b/book.json
@@ -1,5 +1,8 @@
 {
   "author": "The Starterkit team and contributors",
+  "structure": {
+      "readme": "gitbook_readme.md"
+  },
   "plugins": [
     "-sharing",
     "panels@git+https://github.com/lhcb/gitbook-plugin-panels.git#master",

--- a/gitbook_readme.md
+++ b/gitbook_readme.md
@@ -1,0 +1,4 @@
+# LHCb Glossary
+
+Glossary of HEP and LHCb-specific terms and concepts - make a pull request at <https://github.com/lhcb/glossary>
+


### PR DESCRIPTION
Experimental summary on gitbook only.

The readme is now different for the gitbook page, and it links back to the main repository instead of linking to itself. And, a summary of all terms is created on that page as well.

I think this addresses #19 and local discussions elegantly, without making a massive single page.