### PR TITLE
Adding catchy text

### DIFF
--- a/.ci/prepare.py
+++ b/.ci/prepare.py
@@ -21,12 +21,18 @@ title_pattern = re.compile(r'''
 
 DIR = Path(__file__).resolve().parent
 base = './glossary'
+terms = '## Summary of terms'
 
+# Read in old readme
+with open('gitbook_readme.md', 'r') as f:
+    txt = f.read()
+
+# Make new readme; remove terms if this was run more than once
 with open('gitbook_readme.md', 'w') as out:
-    print("# LHCb Glossary\n", file=out)
-    print("Glossary of HEP and LHCb-specific terms and concepts - make a pull request at <https://github.com/lhcb/glossary>.\n", file=out)
-    print("Contributions to the glossary are highly encouraged. Please see the [contributing guide](https://github.com/lhcb/glossary/blob/master/CONTRIBUTING.md) for details.\n", file=out)
-    print("## Terms:\n", file=out)
+
+    intro = txt.split(terms)[0]
+    print(intro, file=out)
+    print(terms, file=out)
 
     for fn in sorted((DIR.parent / 'glossary').glob('?.md')):
         letter = fn.stem

--- a/gitbook_readme.md
+++ b/gitbook_readme.md
@@ -1,3 +1,10 @@
 # LHCb Glossary
 
-Glossary of HEP and LHCb-specific terms and concepts - make a pull request at <https://github.com/lhcb/glossary>.
+A glossary of HEP and LHCb-specific terms and concepts.
+
+Don't see the term you are looking for? Open an [issue]!
+Or [contribute] with a pull request at <https://github.com/lhcb/glossary>.
+
+[issue]: https://github.com/lhcb/glossary/issues
+[contribue]: https://github.com/lhcb/glossary/blob/master/CONTRIBUTING.md
+


### PR DESCRIPTION
The text now really is inside gitbook_readme.md, the python script just appends to it; it's now smart enough so a rerun won't add a doubled term list.