### PR TITLE
Added new defintions 

### DIFF
--- a/glossary/A.md
+++ b/glossary/A.md
@@ -4,3 +4,7 @@
 
 Analysis preservation tackles the topic of reproducibility of studies and results made by members of the collaboration.
 [Twiki](https://twiki.cern.ch/twiki/bin/view/LHCb/AnalysisPreservationReproducibility) for AP documentation in LHCb.
+
+## ASIC: application specific integrated circuit {#ASIC}
+
+Application specific integrated circuit.

--- a/glossary/A.md
+++ b/glossary/A.md
@@ -5,6 +5,6 @@
 Analysis preservation tackles the topic of reproducibility of studies and results made by members of the collaboration.
 [Twiki](https://twiki.cern.ch/twiki/bin/view/LHCb/AnalysisPreservationReproducibility) for AP documentation in LHCb.
 
-## ASIC: application specific integrated circuit {#ASIC}
+## ASIC: application-specific integrated circuit {#ASIC}
 
-Application specific integrated circuit.
+See the [Wikipedia definition](https://en.wikipedia.org/wiki/Application-specific_integrated_circuit).

--- a/glossary/B.md
+++ b/glossary/B.md
@@ -13,7 +13,7 @@ Python-based physics analysis environment. [Project website](http://lhcbdoc.web.
 ## BPV: Best Primary Vertex {#BPV}
 
 Online: a «primary vertex:PV» with respect to which a particle (or a track) has the smallest «impact parameter:IP».
-Offline: a primary vertex with respect to which a particle (or a track) has the smallest $$IP\chi^{2}$$. 
+Offline: a primary vertex with respect to which a particle (or a track) has the smallest IP $$\chi^{2}$$. 
 
 ## Bookkeeping
 

--- a/glossary/B.md
+++ b/glossary/B.md
@@ -11,6 +11,10 @@ See [here](https://arxiv.org/abs/1001.2487) for further details (on the Run 1 & 
 
 Python-based physics analysis environment. [Project website](http://lhcbdoc.web.cern.ch/lhcbdoc/bender/).
 
+## BPV: Best Primary Vertex {#BPV}
+
+A primary vertex that a track has the smallest IP$\chi^2$ with. 
+
 ## Bookkeeping
 
 The LHCb data recording and data provenance tool. Every single file ever produced by LHCb centrally-managed «productions:Productions» is recorded by the LHCb Bookkeeping. Users can browse the contents of the Bookkeeping via the [LHCbDIRAC Web Portal](https://lhcb-portal-dirac.cern.ch/DIRAC/?view=tabs&theme=Grey&url_state=1|*LHCbDIRAC.BookkeepingBrowser.classes.BookkeepingBrowser).

--- a/glossary/B.md
+++ b/glossary/B.md
@@ -12,8 +12,8 @@ Python-based physics analysis environment. [Project website](http://lhcbdoc.web.
 
 ## BPV: Best Primary Vertex {#BPV}
 
-Online: a «primary vertex:PV» that a track has the smallest «impact parameter:IP» with.
-Offline: a primary vertex that a particle has the smallest $$IP\chi^{2}$$ with. 
+Online: a «primary vertex:PV» with respect to which a particle (or a track) has the smallest «impact parameter:IP».
+Offline: a primary vertex with respect to which a particle (or a track) has the smallest $$IP\chi^{2}$$. 
 
 ## Bookkeeping
 

--- a/glossary/B.md
+++ b/glossary/B.md
@@ -12,8 +12,8 @@ Python-based physics analysis environment. [Project website](http://lhcbdoc.web.
 
 ## BPV: Best Primary Vertex {#BPV}
 
-Online: a primary vertex that a track has the smallest IP with.
-Offline: a primary vertex that a particle has the smallest $IP\chi^2$ with. 
+Online: a «primary vertex:PV» that a track has the smallest «impact parameter:IP» with.
+Offline: a primary vertex that a particle has the smallest $$IP\chi^{2}$$ with. 
 
 ## Bookkeeping
 

--- a/glossary/B.md
+++ b/glossary/B.md
@@ -6,7 +6,6 @@ A system to detect possible LHC malfunction and protect LHCb against possible da
 The BCM consists of two stations with 8 diamond sensors each symetrically distributed around the beampipe. The BCM-U is located upstream and the BCM-D downstream of the interaction region. For Run 3 and beyond the BCM stations are equipped with new sets of diamond sensors.
 See [here](https://arxiv.org/abs/1001.2487) for further details (on the Run 1 & 2 version of the BCM).
 
-
 ## Bender
 
 Python-based physics analysis environment. [Project website](http://lhcbdoc.web.cern.ch/lhcbdoc/bender/).

--- a/glossary/B.md
+++ b/glossary/B.md
@@ -13,7 +13,8 @@ Python-based physics analysis environment. [Project website](http://lhcbdoc.web.
 
 ## BPV: Best Primary Vertex {#BPV}
 
-A primary vertex that a track has the smallest IP$\chi^2$ with. 
+Online: a primary vertex that a track has the smallest IP with.
+Offline: a primary vertex that a particle has the smallest $IP\chi^2$ with. 
 
 ## Bookkeeping
 

--- a/glossary/C.md
+++ b/glossary/C.md
@@ -24,7 +24,7 @@ A service at a grid site that runs jobs. For example `LCG.CERN.cern`, `LCG.RAL.u
 
 ## CLARO {#CLARO}
 
-CLARO is a customized 8 channel ASIC CMOS chip used to read-out «RICH» «MaPMT»s in Upgrade 1. 
+CLARO is a customized 8-channel «ASIC» CMOS chip used to read out «RICH» «MaPMT»s in Upgrade I. 
 It is a digital board with a binary output: either 0 or 1. 
 Each channel is calibrated separately to find the most optimal threshold.
 The threshold defines whether 1 (signal) or 0 (no signal) will be transmitted.

--- a/glossary/C.md
+++ b/glossary/C.md
@@ -24,8 +24,8 @@ A service at a grid site that runs jobs. For example `LCG.CERN.cern`, `LCG.RAL.u
 
 ## CLARO {#CLARO}
 
-CLARO is a customized 8-channel «ASIC» CMOS chip used to read out «RICH» «MaPMT»s in Upgrade I. 
-It is a digital board with a binary output. 
+CLARO is a customized 8-channel «ASIC» CMOS chip used to read out «RICH» «MaPMT»s in Upgrade I.
+It is a digital board with a binary output.
 Each channel is calibrated separately to find the most optimal threshold.
 The threshold defines whether 1 (signal) or 0 (no signal) will be transmitted.
 

--- a/glossary/C.md
+++ b/glossary/C.md
@@ -22,6 +22,13 @@ The ultimate authority within LHCb representing all institutes within the collab
 
 A service at a grid site that runs jobs. For example `LCG.CERN.cern`, `LCG.RAL.uk`.
 
+## CLARO {#CLARO}
+
+CLARO is a cusotmized 8 channle ASIC CMOS chip used to read-out RICH MaPMTs in Upgrade 1. 
+It is a digital board with a binary output: either 0 or 1. 
+Each channel is calibrated separately to find the most optimal threshold.
+The threshold defines whether 1 (signal) or 0 (no signal) will be transmiited.
+
 ## CVMFS: CERN Virtual Machine File System {#CVMFS}
 
 [CVMFS](https://cernvm.cern.ch/portal/filesystem) is a network file system based on HTTP and optimised to deliver experiment software

--- a/glossary/C.md
+++ b/glossary/C.md
@@ -24,10 +24,10 @@ A service at a grid site that runs jobs. For example `LCG.CERN.cern`, `LCG.RAL.u
 
 ## CLARO {#CLARO}
 
-CLARO is a cusotmized 8 channle ASIC CMOS chip used to read-out RICH MaPMTs in Upgrade 1. 
+CLARO is a customized 8 channel ASIC CMOS chip used to read-out RICH MaPMTs in Upgrade 1. 
 It is a digital board with a binary output: either 0 or 1. 
 Each channel is calibrated separately to find the most optimal threshold.
-The threshold defines whether 1 (signal) or 0 (no signal) will be transmiited.
+The threshold defines whether 1 (signal) or 0 (no signal) will be transmitted.
 
 ## CVMFS: CERN Virtual Machine File System {#CVMFS}
 

--- a/glossary/C.md
+++ b/glossary/C.md
@@ -25,7 +25,7 @@ A service at a grid site that runs jobs. For example `LCG.CERN.cern`, `LCG.RAL.u
 ## CLARO {#CLARO}
 
 CLARO is a customized 8-channel «ASIC» CMOS chip used to read out «RICH» «MaPMT»s in Upgrade I. 
-It is a digital board with a binary output: either 0 or 1. 
+It is a digital board with a binary output. 
 Each channel is calibrated separately to find the most optimal threshold.
 The threshold defines whether 1 (signal) or 0 (no signal) will be transmitted.
 

--- a/glossary/C.md
+++ b/glossary/C.md
@@ -24,7 +24,7 @@ A service at a grid site that runs jobs. For example `LCG.CERN.cern`, `LCG.RAL.u
 
 ## CLARO {#CLARO}
 
-CLARO is a customized 8 channel ASIC CMOS chip used to read-out RICH MaPMTs in Upgrade 1. 
+CLARO is a customized 8 channel ASIC CMOS chip used to read-out «RICH» «MaPMT»s in Upgrade 1. 
 It is a digital board with a binary output: either 0 or 1. 
 Each channel is calibrated separately to find the most optimal threshold.
 The threshold defines whether 1 (signal) or 0 (no signal) will be transmitted.

--- a/glossary/D.md
+++ b/glossary/D.md
@@ -16,7 +16,7 @@ The list of all decay files available can be found [here](http://lhcbdoc.web.cer
 
 ## Delphes {#Delphes}
 
-A fully parametric fast simulation technique where not only the detector response, but also the reconstruction is parametrized. See more [here](https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_02024.pdf).
+A fully parametric fast simulation technique where not only the detector response, but also the reconstruction, is parametrized. See more [here](https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_02024.pdf).
 
 ## DIRA: Direction angle {#DIRA}
 

--- a/glossary/D.md
+++ b/glossary/D.md
@@ -1,5 +1,9 @@
 # D
 
+## DAQ {#DAQ}
+
+Data Acquisition system.
+
 ## DaVinci {#DaVinci}
 
 Event selection and data analysis application. [Project website](http://lhcbdoc.web.cern.ch/lhcbdoc/davinci/).
@@ -9,6 +13,10 @@ Event selection and data analysis application. [Project website](http://lhcbdoc.
 A file that defines the properties of a specific decay or a set of decay chains of one or several particles. Such ```.dec``` option files are used by «Gauss» to determine what exactly gets generated. In LHCb the decay file for a specific process is named with a "nickname". For example, ```Bd_KpiKpi=TightCut.dec```. The options file for «Gauss», generated from the decay file, has a naming convention: ```<EventType>.py``` (see. «EventType»).
 For Standard Model particles the properties are taken from the "master file" ```DECAY.DEC``, which contains the full set of decay chains know to and used within LHCb by EvtGen. 
 The list of all decay files available can be found [here](http://lhcbdoc.web.cern.ch/lhcbdoc/decfiles/). 
+
+## Delphes {#Delphes}
+
+A fully parametric fast simulation technique where not only the detector response, but also the reconstruction is parametrized. See more [here](https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_02024.pdf).
 
 ## DIRA: Direction angle {#DIRA}
 

--- a/glossary/D.md
+++ b/glossary/D.md
@@ -16,7 +16,8 @@ The list of all decay files available can be found [here](http://lhcbdoc.web.cer
 
 ## Delphes {#Delphes}
 
-A fully parametric fast simulation technique where not only the detector response, but also the reconstruction, is parametrized. See more [here](https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_02024.pdf).
+A fully parametric fast simulation technique where not only the detector response, but also the reconstruction, is parametrized. 
+See more [here](https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_02024.pdf).
 
 ## DIRA: Direction angle {#DIRA}
 

--- a/glossary/F.md
+++ b/glossary/F.md
@@ -11,9 +11,11 @@ A family of Monte Carlo speed-up simulation techniques developed for the LHCb si
 + SplitSim
 
 ## FD: flight distance {#FD}
+
 Distance a particle has travelled from a vertex, reconstructed as the distance between a vertex and the decay vertex of the particle. Usually defined with respect to the associated «primary vertex:PV» or the «vertex of origin:ORIGINVERTEX».
 
 ## FDCHI2: flight distance $$\chi^2$$ {#FDCHI2}
+
 $$\chi^2$$ of the «flight distance:FD» of a particle ($$\chi_\text{FD}^2$$) with respect to a vertex. A measure for how well the decay vertex of the particle can be separated from a vertex.
 
 ## FEST: Full Experiment System Test {#FEST}

--- a/glossary/F.md
+++ b/glossary/F.md
@@ -26,9 +26,6 @@ The first FEST was made in 2008–2009 in preparation for Run 1. A FEST in prepa
 
 (In LHCb typically) Determination of the sign of the bottomness of a meson at production. I.e. if it was a B or an anti-B at production.
 
-## FPGA: Field Programmable Gate Array {#FPGA}
-
-
 ## FT
 
 Abbreviation for:

--- a/glossary/F.md
+++ b/glossary/F.md
@@ -7,7 +7,6 @@ A family of Monte Carlo speed-up simulation techniques developed for the LHCb si
 + «ReDecay»
 + «TrackerOnly»
 + «RICHless»
-<<<<<<< HEAD
 + «Lamarr»
 + SplitSim
 
@@ -22,10 +21,6 @@ $$\chi^2$$ of the «flight distance:FD» of a particle ($$\chi_\text{FD}^2$$) wi
 A FEST is designed to be an end-to-end test of the experiment's online and offline processing chains. Simulated data is propagated through the trigger system (online) and then through DIRAC transformations to run offline jobs on the distributed computing system. The aim is to mimick real data-taking conditions as closely as possible in order to discover, diagnose, and fix any issues that may be present.
 
 The first FEST was made in 2008–2009 in preparation for Run 1. A FEST in preparation for Run 3 is [foreseen](https://indico.cern.ch/event/1006607/) sometime in the summer of 2021.
-
-=======
-+ «Delphes»
-+ SplitSim
 
 ## Flavour Tagging
 

--- a/glossary/F.md
+++ b/glossary/F.md
@@ -7,6 +7,7 @@ A family of Monte Carlo speed-up simulation techniques developed for the LHCb si
 + «ReDecay»
 + «TrackerOnly»
 + «RICHless»
+<<<<<<< HEAD
 + «Lamarr»
 + SplitSim
 
@@ -22,9 +23,16 @@ A FEST is designed to be an end-to-end test of the experiment's online and offli
 
 The first FEST was made in 2008–2009 in preparation for Run 1. A FEST in preparation for Run 3 is [foreseen](https://indico.cern.ch/event/1006607/) sometime in the summer of 2021.
 
+=======
++ «Delphes»
++ SplitSim
+
 ## Flavour Tagging
 
 (In LHCb typically) Determination of the sign of the bottomness of a meson at production. I.e. if it was a B or an anti-B at production.
+
+## FPGA: Field Programmable Gate Array {#FPGA}
+
 
 ## FT
 

--- a/glossary/G.md
+++ b/glossary/G.md
@@ -17,7 +17,6 @@ The LHCb simulation application. [Project website](http://lhcbdoc.web.cern.ch/lh
 A serializer-de-serializer chip receiving and transmitting serial data at 4.8 Gb/s, that uses GBT protocol.
 See [The GBT project](https://cds.cern.ch/record/1235836/files/p342).
 
-
 ## GEANT4: GEometry ANd Tracking 4 {#GEANT4}
 
 A software package which is used for simulating the processes that occur between as particles move through matter.

--- a/glossary/G.md
+++ b/glossary/G.md
@@ -12,6 +12,12 @@ The **LHCb** software framework, see the [Gaudi homepage](http://gaudi.web.cern.
 
 The LHCb simulation application. [Project website](http://lhcbdoc.web.cern.ch/lhcbdoc/gauss/).
 
+## GBTx: Gigabit Transceiver chip {#GBTx}
+
+A serializer-de-serializer chip receiving and transmitting serial data at 4.8 Gb/s, that uses GBT protocol.
+See [The GBT project](https://cds.cern.ch/record/1235836/files/p342).
+
+
 ## GEANT4: GEometry ANd Tracking 4 {#GEANT4}
 
 A software package which is used for simulating the processes that occur between as particles move through matter.

--- a/glossary/H.md
+++ b/glossary/H.md
@@ -9,6 +9,12 @@ Like the «ECAL», it is a sampling calorimeter made of layers of iron and plast
 
 Software trigger. Software that decides if data from the detectore gets written to storage or thrown away.
 
+## HPD: Hybrid Photon Detectors {#HPD}
+
+A vacuum photodetector, that consists of vacuum photon tube and a pixel silicon detector.
+HPDs were used in the original LHCb design (Run 1 and Run 2).
+The radius of the HPD was 72 mm with 8192 pixels, that were combined into 1024 super-pixels, each 8 pixels size.
+
 ## HS06
 HEP-wide benchmark for measuring CPU performance based on the [SPEC2006 benchmark](https://www.spec.org).
 

--- a/glossary/H.md
+++ b/glossary/H.md
@@ -11,7 +11,7 @@ Software trigger. Software that decides if data from the detectore gets written 
 
 ## HPD: Hybrid Photon Detectors {#HPD}
 
-A vacuum photodetector, that consists of vacuum photon tube and a pixel silicon detector.
+A vacuum photodetector, that consists of a vacuum photon tube and a pixel silicon detector.
 HPDs were used in the original LHCb design (Run 1 and Run 2).
 The radius of the HPD was 72 mm with 8192 pixels, that were combined into 1024 super-pixels, each 8 pixels size.
 

--- a/glossary/M.md
+++ b/glossary/M.md
@@ -10,7 +10,7 @@ Outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels.
 
 ## MiniDAQ {#MiniDAQ}
 
-A readout system development stage server that hosts «timing and fast control system:TFC» and «data acquisition:DAQ» systems, see [LHCb MiniDAQ control system](https://cds.cern.ch/record/2702137/files/10.1051_epjconf_201921401005.pdf).
+A readout system development stage server that hosts «timing and fast control system:TFC» and «data acquisition:DAQ» systems, see the [MiniDAQ control system](https://cds.cern.ch/record/2702137/files/10.1051_epjconf_201921401005.pdf) document.
 
 ## Moore
 

--- a/glossary/M.md
+++ b/glossary/M.md
@@ -3,10 +3,10 @@
 ## MaPMT: Multianode-Photomultiplier Tubes {#MaPMT}
 
 A vacuum photodetector, that consists of a set of dynodes under graded potential.
-MaPMTs were installed with Upgrade-1 in RICH 1 and RICH 2.
+MaPMTs were installed in RICH 1 and RICH 2 for Upgrade I.
 They replace the previous photodetectors, called «HPD».
-RICH 1 and inner parts of RICH 2 are covered by the 25.4 x 25.4 mm MaPMTs with 64 channels.
-Outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels. 
+RICH 1 and the inner parts of RICH 2 are covered by the 25.4 x 25.4 mm MaPMTs with 64 channels.
+The outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels.
 
 ## MiniDAQ {#MiniDAQ}
 

--- a/glossary/M.md
+++ b/glossary/M.md
@@ -2,15 +2,15 @@
 
 ## MaPMT: Multianode-Photomultiplier Tubes {#MaPMT}
 
-A vaccum photodetector, that consists of a set of dynodes under graded potential.
+A vacuum photodetector, that consists of a set of dynodes under graded potential.
 MaPMTs were installed with Upgrade-1 in RICH 1 and RICH 2.
-They replaces the previous photodetectors, called HPD.
+They replace the previous photodetectors, called HPD.
 RICH 1 and inner parts of RICH 2 are covered by the 25.4 x 25.4 mm MaPMTs with 64 channels.
 Outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels. 
 
 ## MiniDAQ {#MiniDAQ}
 
-Readout system development stage server that hosts [TFC](#TFC) and [DAQ](#DAQ) systems, see [LHCb MiniDAQ control system](https://cds.cern.ch/record/2702137/files/10.1051_epjconf_201921401005.pdf).
+A readout system development stage server that hosts [TFC](#TFC) and [DAQ](#DAQ) systems, see [LHCb MiniDAQ control system](https://cds.cern.ch/record/2702137/files/10.1051_epjconf_201921401005.pdf).
 
 ## Moore
 

--- a/glossary/M.md
+++ b/glossary/M.md
@@ -4,7 +4,7 @@
 
 A vacuum photodetector, that consists of a set of dynodes under graded potential.
 MaPMTs were installed with Upgrade-1 in RICH 1 and RICH 2.
-They replace the previous photodetectors, called HPD.
+They replace the previous photodetectors, called [HPD](#HPD).
 RICH 1 and inner parts of RICH 2 are covered by the 25.4 x 25.4 mm MaPMTs with 64 channels.
 Outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels. 
 

--- a/glossary/M.md
+++ b/glossary/M.md
@@ -4,7 +4,7 @@
 
 A vacuum photodetector, that consists of a set of dynodes under graded potential.
 MaPMTs were installed with Upgrade-1 in RICH 1 and RICH 2.
-They replace the previous photodetectors, called [HPD](#HPD).
+They replace the previous photodetectors, called «HPD».
 RICH 1 and inner parts of RICH 2 are covered by the 25.4 x 25.4 mm MaPMTs with 64 channels.
 Outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels. 
 

--- a/glossary/M.md
+++ b/glossary/M.md
@@ -10,7 +10,7 @@ Outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels.
 
 ## MiniDAQ {#MiniDAQ}
 
-A readout system development stage server that hosts [TFC](#TFC) and [DAQ](#DAQ) systems, see [LHCb MiniDAQ control system](https://cds.cern.ch/record/2702137/files/10.1051_epjconf_201921401005.pdf).
+A readout system development stage server that hosts «timing and fast control system:TFC» and «data acquisition:DAQ» systems, see [LHCb MiniDAQ control system](https://cds.cern.ch/record/2702137/files/10.1051_epjconf_201921401005.pdf).
 
 ## Moore
 

--- a/glossary/M.md
+++ b/glossary/M.md
@@ -1,5 +1,17 @@
 # M
 
+## MaPMT: Multianode-Photomultiplier Tubes {#MaPMT}
+
+A vaccum photodetector, that consists of a set of dynodes under graded potential.
+MaPMTs were installed with Upgrade-1 in RICH 1 and RICH 2.
+They replaces the previous photodetectors, called HPD.
+RICH 1 and inner parts of RICH 2 are covered by the 25.4 x 25.4 mm MaPMTs with 64 channels.
+Outer area of RICH 2 is covered with 50.8 x 50.8 mm MaPMTs with 64 channels. 
+
+## MiniDAQ {#MiniDAQ}
+
+Readout system development stage server that hosts [TFC](#TFC) and [DAQ](#DAQ) systems, see [LHCb MiniDAQ control system](https://cds.cern.ch/record/2702137/files/10.1051_epjconf_201921401005.pdf).
+
 ## Moore
 
 The LHCb trigger emulation application. [Project website](http://lhcbdoc.web.cern.ch/lhcbdoc/moore/) .

--- a/glossary/O.md
+++ b/glossary/O.md
@@ -3,7 +3,7 @@
 ## ODIN {#ODIN}
 
 A readout supervision module of [TFC](#TFC), see [The final LHCb readout supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) for LHCb Run 1/Run 2 version.
-In Upgrade 1 an updated version is called [S-ODIN](#S_ODIN).
+An updated version used in Upgrade 1 is called [S-ODIN](#S_ODIN).
 
 ## OPG: Operation Planning Group {#OPG}
 

--- a/glossary/O.md
+++ b/glossary/O.md
@@ -2,7 +2,7 @@
 
 ## ODIN {#ODIN}
 
-A readout supervision module of «timing and fact control:TFC», see [The final LHCb readout supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) for LHCb Run 1/Run 2 version.
+A readout supervision module of «timing and fact control:TFC», see the final [Readout Supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) document for Runs 1 and Run 2.
 An updated version used in Upgrade 1 is called «S-ODIN:S_ODIN».
 
 ## OPG: Operation Planning Group {#OPG}

--- a/glossary/O.md
+++ b/glossary/O.md
@@ -3,7 +3,7 @@
 ## ODIN {#ODIN}
 
 A readout supervision module of «timing and fact control:TFC», see the final [Readout Supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) document for Runs 1 and Run 2.
-An updated version used in Upgrade 1 is called «S-ODIN:S_ODIN».
+An updated version used in Upgrade I is called «S-ODIN:S_ODIN».
 
 ## OPG: Operation Planning Group {#OPG}
 

--- a/glossary/O.md
+++ b/glossary/O.md
@@ -1,5 +1,10 @@
 # O
 
+## ODIN {#ODIN}
+
+A readout supervisor module of [TFC](#TFC), see [The final LHCb readout supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) for LHCb Run 1/Run 2 version.
+In Upgrade 1 an updated version is called [S-ODIN](#S_ODIN).
+
 ## OPG: Operation Planning Group {#OPG}
 
 Advisory body to the LHCb management that is responsible for collecting and processing data according to the priorities set out by the «PPG».

--- a/glossary/O.md
+++ b/glossary/O.md
@@ -2,7 +2,7 @@
 
 ## ODIN {#ODIN}
 
-A readout supervisor module of [TFC](#TFC), see [The final LHCb readout supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) for LHCb Run 1/Run 2 version.
+A readout supervision module of [TFC](#TFC), see [The final LHCb readout supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) for LHCb Run 1/Run 2 version.
 In Upgrade 1 an updated version is called [S-ODIN](#S_ODIN).
 
 ## OPG: Operation Planning Group {#OPG}

--- a/glossary/O.md
+++ b/glossary/O.md
@@ -2,8 +2,8 @@
 
 ## ODIN {#ODIN}
 
-A readout supervision module of [TFC](#TFC), see [The final LHCb readout supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) for LHCb Run 1/Run 2 version.
-An updated version used in Upgrade 1 is called [S-ODIN](#S_ODIN).
+A readout supervision module of «timing and fact control:TFC», see [The final LHCb readout supervisor ODIN](https://cds.cern.ch/record/619217/files/p371.pdf) for LHCb Run 1/Run 2 version.
+An updated version used in Upgrade 1 is called «S-ODIN:S_ODIN».
 
 ## OPG: Operation Planning Group {#OPG}
 

--- a/glossary/P.md
+++ b/glossary/P.md
@@ -7,7 +7,7 @@ Graphical display of detector and event information. [Project website](http://lh
 ## PCIe40: PCIexpress {#PCIe40}
 
 «Readout boards:ReadoutBoard» used for the «data acquisition system:DAQ», «Experiment Control System:ECS» and «Timing and Fast Control:TFC». Refer to the [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) for details.
-Each board has 48 bidirectional optical links for interfacing with frontend electronics and one bidirectional optical link for interfacing the TFC.
+Each board has 48 bidirectional optical links for interfacing with frontend electronics and one bidirectional optical link for interfacing the «TDC».
 
 ## PFN: Physical File Name {#PFN}
 

--- a/glossary/P.md
+++ b/glossary/P.md
@@ -6,7 +6,7 @@ Graphical display of detector and event information. [Project website](http://lh
 
 ## PCIe40: PCIexpress {#PCIe40}
 
-«Readout boards:ReadoutBoard» used for the «data acquisition system:DAQ», «Experiment control system:ECS» and «timing and fast control:TFC», see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
+«Readout boards:ReadoutBoard» used for the «data acquisition system:DAQ», «Experiment Control System:ECS» and «Timing and Fast Control:TFC». Refer to the [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) for details.
 Each board has 48 bidirectional optical links for interfacing with frontend electronics and one bidirectional optical link for interfacing the TFC.
 
 ## PFN: Physical File Name {#PFN}

--- a/glossary/P.md
+++ b/glossary/P.md
@@ -6,8 +6,8 @@ Graphical display of detector and event information. [Project website](http://lh
 
 ## PCIe40: PCIexpress {#PCIe40}
 
-[Readout boards](#ReadoutBoard) used for the [DAQ](#DAQ), [ECS](#ECS) and [TFC](#TFC), see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
-Each board has 48 bidirectional optical links for interfacing with frontend electronics and one bidirectional optical link for interfacing the [TFC](#TFC).
+«Readout boards:ReadoutBoard» used for the «data acquisition system:DAQ», «Experiment control system:ECS» and «timing and fast control:TFC», see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
+Each board has 48 bidirectional optical links for interfacing with frontend electronics and one bidirectional optical link for interfacing the TFC.
 
 ## PFN: Physical File Name {#PFN}
 

--- a/glossary/P.md
+++ b/glossary/P.md
@@ -7,7 +7,7 @@ Graphical display of detector and event information. [Project website](http://lh
 ## PCIe40: PCIexpress {#PCIe40}
 
 «Readout boards:ReadoutBoard» used for the «data acquisition system:DAQ», «Experiment Control System:ECS» and «Timing and Fast Control:TFC». Refer to the [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) for details.
-Each board has 48 bidirectional optical links for interfacing with frontend electronics and one bidirectional optical link for interfacing the «TDC».
+Each board has 48 bidirectional optical links for interfacing with the frontend electronics and one bidirectional optical link for interfacing with the «TFC».
 
 ## PFN: Physical File Name {#PFN}
 

--- a/glossary/P.md
+++ b/glossary/P.md
@@ -7,7 +7,7 @@ Graphical display of detector and event information. [Project website](http://lh
 ## PCIe40: PCIexpress {#PCIe40}
 
 [Readout boards](#ReadoutBoard) used for the [DAQ](#DAQ), [ECS](#ECS) and [TFC](#TFC), see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
-Each board has 48 bi-directional optical links for interfacing with fron-end electronics and one bi-directional optical link for interfacing the [TFC](#TFC).
+Each board has 48 bidirectional optical links for interfacing with frontend electronics and one bidirectional optical link for interfacing the [TFC](#TFC).
 
 ## PFN: Physical File Name {#PFN}
 

--- a/glossary/P.md
+++ b/glossary/P.md
@@ -4,6 +4,11 @@
 
 Graphical display of detector and event information. [Project website](http://lhcbdoc.web.cern.ch/lhcbdoc/panoramix/).
 
+## PCIe40: PCIexpress {#PCIe40}
+
+[Readout boards](#ReadoutBoard) used for the [DAQ](#DAQ), [ECS](#ECS) and [TFC](#TFC), see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
+Each board has 48 bi-directional optical links for interfacing with fron-end electronics and one bi-directional optical link for interfacing the [TFC](#TFC).
+
 ## PFN: Physical File Name {#PFN}
 
 A path for a file on the grid, including the physical location to allow for access.

--- a/glossary/R.md
+++ b/glossary/R.md
@@ -4,6 +4,11 @@
 
 Short for restaurant 1 in building 501 at CERN.
 
+## Readout Board {#ReadoutBoard}
+
+A generic component which is designed for data acquisition of all detectors, the distribution of the timing and fast commands and the slow control.  
+In LHCb PCI Express 40 board is used, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
+
 ## ReDecay {#ReDecay}
 
 A fast simulation technique that is based on re-usage of the fully simulated underlying event and re-decaying the signal process multiple times. Further details in [this paper](https://arxiv.org/pdf/1810.10362.pdf) and/or [Twiki](https://twiki.cern.ch/twiki/bin/view/LHCb/FAQ/GeneratorFAQ#How_do_I_use_ReDecay_as_descibed).

--- a/glossary/R.md
+++ b/glossary/R.md
@@ -7,7 +7,7 @@ Short for restaurant 1 in building 501 at CERN.
 ## Readout Board {#ReadoutBoard}
 
 A generic component which is designed for data acquisition of all detectors, distribution of the timing and fast commands and the slow control.  
-In LHCb PCI Express 40 board is used, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [PCIe40](#PCIe40).
+In LHCb PCI Express 40 board is used, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and «PCIe40».
 
 ## ReDecay {#ReDecay}
 

--- a/glossary/R.md
+++ b/glossary/R.md
@@ -6,8 +6,8 @@ Short for restaurant 1 in building 501 at CERN.
 
 ## Readout Board {#ReadoutBoard}
 
-A generic component which is designed for data acquisition of all detectors, the distribution of the timing and fast commands and the slow control.  
-In LHCb PCI Express 40 board is used, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
+A generic component which is designed for data acquisition of all detectors, distribution of the timing and fast commands and the slow control.  
+In LHCb PCI Express 40 board is used, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [PCIe40](#PCIe40).
 
 ## ReDecay {#ReDecay}
 

--- a/glossary/S.md
+++ b/glossary/S.md
@@ -30,7 +30,7 @@ allowing LHCb to be operated in fixed target mode.
 
 ## S-ODIN {#S_ODIN}
 
-A «timing and fast control: TFC» readout supervision module responsible for generating necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
+A «timing and fast control: TFC» readout supervision module responsible for generating necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and «ODIN».
 
 ## SOL40
 

--- a/glossary/S.md
+++ b/glossary/S.md
@@ -30,11 +30,11 @@ allowing LHCb to be operated in fixed target mode.
 
 ## S-ODIN {#S_ODIN}
 
-A [TFC]{#TFC} readout supervisor module responsible for generating the necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
+A [TFC]{#TFC} readout supervision module responsible for generating the necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
 
 ## SOL40
 
-Multiple interface board that connect the front-end and back-end readout electronics of the subdetector to the [S-ODIN]{#S_ODIN} with a set of 3.2 Gb/s high-speed bi-directional optical links, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).  
+A multiple interface board that connects the frontend and backend readout electronics of the subdetector to the [S-ODIN]{#S_ODIN} with a set of 3.2 Gb/s high-speed bidirectional optical links, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).  
 
 ## SPD: Scintillating Pad Detector {#SPD}
 
@@ -53,8 +53,8 @@ One week introduction course into computer usage at LHCb for young students. Wit
 ## sWeights {#sWeights}
 
 A signal/background discrimination technique, that utilizes information about distribution of signal and background events in one variable, called discriminating variable, to get a distribution of the signal and background in the observed variable, called observable.
-From discriminating variable, where the signal and background distributions are known, a weight is computed per event, that represents signal-likeness or backgroun-likeness.
+From a discriminating variable, where the signal and background distributions are known, a weight is computed per event, that represents signal-likeness or background-likeness.
 Strictly speaking discriminating variable and observable should factorize in order to use this technique.
 Several background species might be specified to compute the weights.
 Also known as sPlot. 
-See [sPlot](https://arxiv.org/abs/physics/0402083) and ROOT implementation [SPlot class](https://root.cern/doc/master/classRooStats_1_1SPlot.html).
+See [sPlot paper](https://arxiv.org/abs/physics/0402083) and ROOT implementation [SPlot class](https://root.cern/doc/master/classRooStats_1_1SPlot.html).

--- a/glossary/S.md
+++ b/glossary/S.md
@@ -28,6 +28,14 @@ and the pressure is approximately $$10^{-7}$$ mbar.
 Originally designed for precise luminosity measurements, SMOG injections are also used for specific data takings,
 allowing LHCb to be operated in fixed target mode.
 
+## S-ODIN {#S_ODIN}
+
+A [TFC]{#TFC} readout supervisor module responsible for generating the necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
+
+## SOL40
+
+Multiple interface board that connect the front-end and back-end readout electronics of the subdetector to the [S-ODIN]{#S_ODIN} with a set of 3.2 Gb/s high-speed bi-directional optical links, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).  
+
 ## SPD: Scintillating Pad Detector {#SPD}
 
 The SPD consists of scintillating pads and is placed before the «PS».
@@ -41,3 +49,12 @@ A term that collectively refers to the «TT» and «IT».
 ## Starterkit {#Starterkit}
 
 One week introduction course into computer usage at LHCb for young students. With no prerequisites on Linux usage, teaching basic survival skills including Grid usage and ntuple production. You can find the online version [here](https://lhcb.github.io/starterkit-lessons/index.html).
+
+## sWeights {#sWeights}
+
+A signal/background discrimination technique, that utilizes information about distribution of signal and background events in one variable, called discriminating variable, to get a distribution of the signal and background in the observed variable, called observable.
+From discriminating variable, where the signal and background distributions are known, a weight is computed per event, that represents signal-likeness or backgroun-likeness.
+Strictly speaking discriminating variable and observable should factorize in order to use this technique.
+Several background species might be specified to compute the weights.
+Also known as sPlot. 
+See [sPlot](https://arxiv.org/abs/physics/0402083) and ROOT implementation [SPlot class](https://root.cern/doc/master/classRooStats_1_1SPlot.html).

--- a/glossary/S.md
+++ b/glossary/S.md
@@ -30,11 +30,11 @@ allowing LHCb to be operated in fixed target mode.
 
 ## S-ODIN {#S_ODIN}
 
-A [TFC]{#TFC} readout supervision module responsible for generating the necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
+A [TFC]{#TFC} readout supervision module responsible for generating necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
 
 ## SOL40
 
-A multiple interface board that connects the frontend and backend readout electronics of the subdetector to the [S-ODIN]{#S_ODIN} with a set of 3.2 Gb/s high-speed bidirectional optical links, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).  
+A multiple interface board that connects frontend and backend readout electronics of the subdetector to [S-ODIN]{#S_ODIN} with a set of 3.2 Gb/s high-speed bidirectional optical links, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).  
 
 ## SPD: Scintillating Pad Detector {#SPD}
 
@@ -52,9 +52,9 @@ One week introduction course into computer usage at LHCb for young students. Wit
 
 ## sWeights {#sWeights}
 
-A signal/background discrimination technique, that utilizes information about distribution of signal and background events in one variable, called discriminating variable, to get a distribution of the signal and background in the observed variable, called observable.
-From a discriminating variable, where the signal and background distributions are known, a weight is computed per event, that represents signal-likeness or background-likeness.
+Also known as sPlot.
+A signal/background discrimination technique, that utilizes information about distribution of signal and background events in one variable, called a discriminating variable, to get a distribution of signal and background events in the observed variable, called an observable.
+From a discriminating variable, where signal and background distributions are known, a weight is computed per event, that represents signal-likeness or background-likeness.
 Strictly speaking discriminating variable and observable should factorize in order to use this technique.
-Several background species might be specified to compute the weights.
-Also known as sPlot. 
+Several background species might be specified to compute the weights. 
 See [sPlot paper](https://arxiv.org/abs/physics/0402083) and ROOT implementation [SPlot class](https://root.cern/doc/master/classRooStats_1_1SPlot.html).

--- a/glossary/S.md
+++ b/glossary/S.md
@@ -30,11 +30,11 @@ allowing LHCb to be operated in fixed target mode.
 
 ## S-ODIN {#S_ODIN}
 
-A [TFC]{#TFC} readout supervision module responsible for generating necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
+A «timing and fast control: TFC» readout supervision module responsible for generating necessary information and commands, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf) and [ODIN](#ODIN).
 
 ## SOL40
 
-A multiple interface board that connects frontend and backend readout electronics of the subdetector to [S-ODIN]{#S_ODIN} with a set of 3.2 Gb/s high-speed bidirectional optical links, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).  
+A multiple interface board that connects frontend and backend readout electronics of the subdetector to «S-ODIN:S_ODIN» with a set of 3.2 Gb/s high-speed bidirectional optical links, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).  
 
 ## SPD: Scintillating Pad Detector {#SPD}
 

--- a/glossary/T.md
+++ b/glossary/T.md
@@ -83,10 +83,6 @@ Split into 5 types depending on which parts of the tracking system are used:
 
 [!["Track types in LHCb"](/figures/track_types.png)](/figures/track_types.png)
 
-## Tracker-only {#TrackerOnly}
-
-A fast simulation configuration that excludes «calorimeter:CALO» and «MUON» geometry, but keeps the «RICH» geometry included. However, RICH physics lists are switched off.    
-
 ## Track Type
 
 The type of the track used in `TupleToolTrackInfo`, and anything that includes it. See [Tracking strategies used in LHCb](https://twiki.cern.ch/twiki/bin/view/LHCb/LHCbTrackingStrategies#Track_types) or [TupleToolTrackInfo](https://twiki.cern.ch/twiki/bin/view/LHCb/TupleToolTrackInfo) for details. The types are:
@@ -112,7 +108,7 @@ Much like the «IT» stations, the TT consists of 4 layers of silicon strips, or
 
 ## Tracker-only {#TrackerOnly}
 
-A fast simulation configuration that excludes «calorimeter:CALO» and «MUON» geometries, but keeps the «RICH» geometry included. However, RICH physics lists are switched off.
+A fast simulation configuration that excludes «calorimeter:CALO» and «MUON» geometries but keeps the «RICH» geometry included. However, RICH physics lists are switched off.
 
 ## Tracking efficiency {#TrackingEfficiency}
 Performance number of a tracking algorithm, defined as the amount of reconstructed tracks that can be matched to MC particles with respect to the amount of reconstructible tracks. In offline analysis usually calculated with data-driven tag-and-probe methods on dedicated calibration samples. See references in the [Tracking efficiency TWiki](https://twiki.cern.ch/twiki/bin/viewauth/LHCbInternal/LHCbTrackingEfficiencies) for details.

--- a/glossary/T.md
+++ b/glossary/T.md
@@ -41,9 +41,24 @@ For the LHCb Upgrade I the equivalent document is known as a Framework «TDR», 
 [CERN/LHCC-2012-007](http://cds.cern.ch/record/1443882/files/LHCB-TDR-012.pdf).
 For the LHCb Upgrade II the equivalent document is due to be submitted around late 2020.
 
+## TELL40 {#TELL40}
+
+Readout Boards in Upgrade 1 based on the Advanced Telecommunication Computer Architecture (ATCA) technology.
+TELL40 operates at 40MHz and replaces the previous system TELL1.
+
+## TFC: Timing and Fast Control system {#TFC}
+
+A system responsible for controlling and distributins clock, timing and trigger information, synchronous and asynchronous commands to the entire data readout system, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
+
+
 ## Tier (Grid) {#Tier}
 
 Grid sites are split into tiers depending on their resources. Tier 1 (i.e. RAL, PIC) and tier 2 sites (mostly universities) store data, the tier 1s in particular storing raw data. The tier 3 sites do not store data. See [here for details](http://wlcg-public.web.cern.ch/tier-centres).
+
+## Timepix {#Timepix}
+
+An application specific integrated circuit (ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55um pitch.
+Timepix3 is based on the Medipix/Timepix family of ASICs, and additionally offers the possibilty to measure the time of arrival of the particle.
 
 ## TISTOS
 
@@ -67,6 +82,10 @@ Split into 5 types depending on which parts of the tracking system are used:
 * Velo Track
 
 [!["Track types in LHCb"](/figures/track_types.png)](/figures/track_types.png)
+
+## Tracker-only {#TrackerOnly}
+
+A fast simulation that excludes calorimeter and muon geometry, but keeps the RICH geometry included. However, RICH physics lists are switched off.    
 
 ## Track Type
 

--- a/glossary/T.md
+++ b/glossary/T.md
@@ -57,7 +57,7 @@ Grid sites are split into tiers depending on their resources. Tier 1 (i.e. RAL, 
 
 ## Timepix {#Timepix}
 
-An application specific integrated circuit (ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55um pitch.
+An application specific integrated circuit (ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55$\mu$m pitch.
 Timepix3 is based on the Medipix/Timepix family of ASICs, and additionally offers the possibility to measure the time of arrival of the particle.
 
 ## TISTOS

--- a/glossary/T.md
+++ b/glossary/T.md
@@ -43,7 +43,7 @@ For the LHCb Upgrade II the equivalent document is due to be submitted around la
 
 ## TELL40 {#TELL40}
 
-Readout Boards in Upgrade 1 based on the Advanced Telecommunication Computer Architecture (ATCA) technology.
+«Readout Boards:ReadoutBoard» in Upgrade 1 based on the Advanced Telecommunication Computer Architecture (ATCA) technology.
 TELL40 operates at 40MHz and replaces the previous system TELL1.
 
 ## TFC: Timing and Fast Control system {#TFC}
@@ -57,7 +57,7 @@ Grid sites are split into tiers depending on their resources. Tier 1 (i.e. RAL, 
 
 ## Timepix {#Timepix}
 
-An application specific integrated circuit (ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55$\mu$m pitch.
+An «application specific integrated circuit:ASIC»(ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55$$\mu$$m pitch.
 Timepix3 is based on the Medipix/Timepix family of ASICs, and additionally offers the possibility to measure the time of arrival of the particle.
 
 ## TISTOS
@@ -85,7 +85,7 @@ Split into 5 types depending on which parts of the tracking system are used:
 
 ## Tracker-only {#TrackerOnly}
 
-A fast simulation that excludes calorimeter and muon geometry, but keeps the RICH geometry included. However, RICH physics lists are switched off.    
+A fast simulation that excludes calorimeter and muon geometry, but keeps the «RICH» geometry included. However, RICH physics lists are switched off.    
 
 ## Track Type
 
@@ -112,7 +112,7 @@ Much like the «IT» stations, the TT consists of 4 layers of silicon strips, or
 
 ## Tracker-only {#TrackerOnly}
 
-A fast simulation configuration that excludes calorimeter and muon geometries, but keeps the RICH geometry included. However, RICH physics lists are switched off.
+A fast simulation configuration that excludes «calorimeter:CALO» and «MUON» geometries, but keeps the «RICH» geometry included. However, RICH physics lists are switched off.
 
 ## Tracking efficiency {#TrackingEfficiency}
 Performance number of a tracking algorithm, defined as the amount of reconstructed tracks that can be matched to MC particles with respect to the amount of reconstructible tracks. In offline analysis usually calculated with data-driven tag-and-probe methods on dedicated calibration samples. See references in the [Tracking efficiency TWiki](https://twiki.cern.ch/twiki/bin/viewauth/LHCbInternal/LHCbTrackingEfficiencies) for details.

--- a/glossary/T.md
+++ b/glossary/T.md
@@ -57,7 +57,7 @@ Grid sites are split into tiers depending on their resources. Tier 1 (i.e. RAL, 
 
 ## Timepix {#Timepix}
 
-An «application specific integrated circuit:ASIC»(ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55$$\mu$$m pitch.
+An «application specific integrated circuit:ASIC» (ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55$$\mu$$m pitch.
 Timepix3 is based on the Medipix/Timepix family of ASICs, and additionally offers the possibility to measure the time of arrival of the particle.
 
 ## TISTOS

--- a/glossary/T.md
+++ b/glossary/T.md
@@ -48,7 +48,7 @@ TELL40 operates at 40MHz and replaces the previous system TELL1.
 
 ## TFC: Timing and Fast Control system {#TFC}
 
-A system responsible for controlling and distributins clock, timing and trigger information, synchronous and asynchronous commands to the entire data readout system, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
+A system responsible for controlling and distributing clock, timing and trigger information, synchronous and asynchronous commands to the entire data readout system, see [LHCb Trigger and Online TDR](https://cds.cern.ch/record/1701361/files/LHCB-TDR-016.pdf).
 
 
 ## Tier (Grid) {#Tier}
@@ -58,7 +58,7 @@ Grid sites are split into tiers depending on their resources. Tier 1 (i.e. RAL, 
 ## Timepix {#Timepix}
 
 An application specific integrated circuit (ASIC) used in hybrid pixel detectors and has 256x256 pixels of 55um pitch.
-Timepix3 is based on the Medipix/Timepix family of ASICs, and additionally offers the possibilty to measure the time of arrival of the particle.
+Timepix3 is based on the Medipix/Timepix family of ASICs, and additionally offers the possibility to measure the time of arrival of the particle.
 
 ## TISTOS
 

--- a/glossary/V.md
+++ b/glossary/V.md
@@ -8,7 +8,7 @@
 
 The ASIC used in Upgrade 1 Velo, and is based on Timepix3 ASIC technology.
 Contrary to Timepix3, the Velopix ASIC does not give information about the deposited charge in the detector. 
-It assigns the hits to time bins of 25 ns (syncronous with the bunch crossing period).
+It assigns the hits to time bins of 25 ns (synchronous with the bunch crossing period).
 
 ## VO: Virtual Organisation {#VO}
 

--- a/glossary/V.md
+++ b/glossary/V.md
@@ -6,7 +6,7 @@
 
 ## VeloPix {#Velopix}
 
-The ASIC used in Upgrade 1 Velo, which is based on Timepix3 ASIC technology.
+The «application specific integrated circuit:ASIC» (ASIC) used in Upgrade 1 Velo, which is based on «Timepix3:Timepix» ASIC technology.
 Contrary to Timepix3, the Velopix ASIC does not give information about the deposited charge in the detector. 
 It assigns the hits to time bins of 25 ns (synchronous with the bunch crossing period).
 

--- a/glossary/V.md
+++ b/glossary/V.md
@@ -4,6 +4,12 @@
 
 [Twiki](https://lbtwiki.cern.ch/bin/view/VELO) for the VELO project.
 
+## VeloPix {#Velopix}
+
+The ASIC used in Upgrade 1 Velo, and is based on Timepix3 ASIC technology.
+Contrary to Timepix3, the Velopix ASIC does not give information about the deposited charge in the detector. 
+It assigns the hits to time bins of 25 ns (syncronous with the bunch crossing period).
+
 ## VO: Virtual Organisation {#VO}
 
 Each LHC experiment is a VO by means of which users are centrally managed for example for authorisations in the WLCG infrastructure.

--- a/glossary/V.md
+++ b/glossary/V.md
@@ -6,7 +6,7 @@
 
 ## VeloPix {#Velopix}
 
-The ASIC used in Upgrade 1 Velo, and is based on Timepix3 ASIC technology.
+The ASIC used in Upgrade 1 Velo, which is based on Timepix3 ASIC technology.
 Contrary to Timepix3, the Velopix ASIC does not give information about the deposited charge in the detector. 
 It assigns the hits to time bins of 25 ns (synchronous with the bunch crossing period).
 


### PR DESCRIPTION
Adding definitions of BPV, CLARO, Delphes, GBTx, HPD, MaPMT, MiniDAQ, ODIN, PCIe40, Readout board, sODIN, SOL40, sWeights, TELL40, TFC, Timepix, Tracker-only, VeloPix

Crediting also Robbert Geertsema for a great review of the Timepix and Velopix definitions. 

I am not really sure but some github ci test for creating a github book fails because I don't have some token... 

